### PR TITLE
Speed up feature extraction using batch level parallelisation with da…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ numpy
 torch
 transformers
 setuptools
+tqdm


### PR DESCRIPTION
…ta loaders

**Benchmark encoding task ("Hello world" * 1000) sped up from 48 seconds to 10 seconds (~4x faster) using batch_size = 10.** Feature generation can be further sped up with a larger batch_size to the extent that gpu has enough space.

**With batch level parallelization**
```
input_strings = ["Hello world"] * 1000
res_dl = tfe.encode(input_strings, batch_size=10)
# 100%|██████████| 100/100 [00:10<00:00,  9.48it/s]
```
**Without batch level parallelization**
```
res_non_dl = fe_old.encode(input_strings)
# 100%|██████████| 1000/1000 [00:48<00:00, 20.65it/s]
```